### PR TITLE
add alias feature

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,8 @@
 
 ## New feature
 
-- [ ] alias
+- [x] alias
+- [ ] defaut alias
 - [ ] automatically `use` when `install` first time
 - [ ] auto version switching via `.php-version`
 - [ ] colorize output

--- a/src/alias.rs
+++ b/src/alias.rs
@@ -1,0 +1,34 @@
+use crate::version::Version;
+use derive_more::{Display, FromStr};
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+#[derive(Debug, Display, FromStr, PartialEq, Eq, Hash)]
+pub struct Alias(String);
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Can't resolve alias: {0}")]
+    NotFoundAliasError(String),
+    #[error("Can't find version: {0}`")]
+    NotFoundVersionError(String),
+}
+
+impl Alias {
+    pub fn symlink_path(&self, aliases_dir: impl AsRef<Path>) -> PathBuf {
+        aliases_dir.as_ref().join(&self.0)
+    }
+    // read symbolic link
+    pub fn resolve(&self, aliases_dir: impl AsRef<Path>) -> Result<(PathBuf, Version), Error> {
+        let alias_symlink = self.symlink_path(aliases_dir);
+        let version_dir = alias_symlink
+            .read_link()
+            .or(Err(Error::NotFoundAliasError(self.0.clone())))?;
+        let version = version_dir
+            .file_name()
+            .and_then(|os_str| os_str.to_str())
+            .and_then(|s| s.parse::<Version>().ok())
+            .ok_or(Error::NotFoundVersionError(self.0.clone()))?;
+        Ok((version_dir, version))
+    }
+}

--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -1,0 +1,43 @@
+use super::{Command, Config};
+use crate::{alias::Alias as AliasName, symlink, version::Version};
+use std::fs;
+use structopt::StructOpt;
+use thiserror::Error;
+
+#[derive(StructOpt, Debug)]
+pub struct Alias {
+    version: Version,
+    alias: AliasName,
+}
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Can't find installed version `{0}`")]
+    NotInstalledError(Version),
+}
+
+impl Command for Alias {
+    fn run(&self, config: &Config) -> anyhow::Result<()> {
+        let local_versions = config.local_versions();
+        // TODO: funcionarize
+        let version = local_versions
+            .iter()
+            .filter(|local_version| self.version.includes(local_version))
+            .max()
+            .ok_or(Error::NotInstalledError(self.version))?;
+
+        let alias_symlink = self.alias.symlink_path(&config.aliases_dir());
+        if alias_symlink.exists() {
+            fs::remove_file(&alias_symlink).expect("Can't remove alias symbolic link");
+        }
+        let version_dir = config.versions_dir().join(version.to_string());
+        symlink::link(version_dir, alias_symlink).expect("Can't create symlink!");
+
+        println!(
+            "Set `{}` as the alias to {}",
+            self.alias,
+            version.to_string(),
+        );
+        Ok(())
+    }
+}

--- a/src/commands/list_remote.rs
+++ b/src/commands/list_remote.rs
@@ -52,7 +52,8 @@ impl Command for ListRemote {
         };
 
         let local_versions = config.local_versions();
-        let printer = Printer::new(&local_versions, config.current_version());
+        let aliases = config.aliases();
+        let printer = Printer::new(&local_versions, config.current_version(), &aliases);
         featch_and_print_versions(&query_versions, self.only_latest_patch, &printer)?;
         Ok(())
     }

--- a/src/commands/unalias.rs
+++ b/src/commands/unalias.rs
@@ -1,0 +1,29 @@
+use super::{Command, Config};
+use crate::alias::Alias;
+use std::fs;
+use structopt::StructOpt;
+use thiserror::Error;
+
+#[derive(StructOpt, Debug)]
+pub struct Unalias {
+    alias: Alias,
+}
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Can't find alias `{0}`")]
+    NotFoundAliasError(String),
+}
+
+impl Command for Unalias {
+    fn run(&self, config: &Config) -> anyhow::Result<()> {
+        let alias_symlink = self.alias.symlink_path(&config.aliases_dir());
+        if alias_symlink.exists() {
+            fs::remove_file(&alias_symlink).expect("Can't remove alias symbolic link");
+        } else {
+            return Err(Error::NotFoundAliasError(self.alias.to_string()))?;
+        }
+        println!("Remove the alias `{}`", self.alias);
+        Ok(())
+    }
+}

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -1,12 +1,19 @@
 use super::{Command, Config};
-use crate::version::Version;
-use anyhow::anyhow;
+use crate::{symlink, version::Version};
+use colored::Colorize;
 use std::fs;
 use structopt::StructOpt;
+use thiserror::Error;
 
 #[derive(StructOpt, Debug)]
 pub struct Uninstall {
     version: Version,
+}
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Can't find installed version `{0}`")]
+    NotInstalledError(Version),
 }
 
 impl Command for Uninstall {
@@ -14,12 +21,36 @@ impl Command for Uninstall {
         let local_versions = config.local_versions();
         let versions_dir = config.versions_dir();
         if local_versions.contains(&self.version) {
-            let installed_dir = versions_dir.join(self.version.to_string());
-            fs::remove_dir_all(&installed_dir)?;
+            let version = self.version;
+
+            if config.current_version() == Some(version) {
+                symlink::remove(&config.multishell_path.as_ref().unwrap())
+                    .expect("Can't remove symlink!");
+            }
+
+            let version_dir = versions_dir.join(version.to_string());
+            fs::remove_dir_all(&version_dir)?;
+            println!(
+                "Version {} was removed successfully from {:?}",
+                version.to_string().cyan(),
+                version_dir
+            );
+
+            if let Some(aliases) = config.aliases().get(&version) {
+                let aliases_dir = &config.aliases_dir();
+                for alias in aliases {
+                    let alias_symlink = alias.symlink_path(&aliases_dir);
+                    fs::remove_file(&alias_symlink).expect("Can't remove alias symbolic link");
+                    println!(
+                        "Alias {} was removed successfully",
+                        alias.to_string().cyan()
+                    );
+                }
+            }
+            Ok(())
         } else {
-            return Err(anyhow!("Version `{}` isn't installed", self.version));
+            Err(Error::NotInstalledError(self.version))?
         }
-        Ok(())
     }
 }
 

--- a/src/commands/use.rs
+++ b/src/commands/use.rs
@@ -1,53 +1,78 @@
 use super::{Command, Config};
+use crate::alias::Alias;
 use crate::symlink;
 use crate::version::Version;
 use colored::Colorize;
+use derive_more::Display;
+use std::str::FromStr;
 use structopt::StructOpt;
 use thiserror::Error;
 
 #[derive(StructOpt, Debug)]
 pub struct Use {
-    version: Option<Version>,
+    #[structopt(name = "version | alias", help = "semantic version or alias name")]
+    version_name: Option<VersionName>,
+}
+
+#[derive(Debug, Display)]
+enum VersionName {
+    Version(Version),
+    Alias(Alias),
 }
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("Need to run `phpup install {0}`")]
+    #[error("Can't find installed version `{0}`")]
     NotInstalledError(Version),
 }
 
 impl Command for Use {
     fn run(&self, config: &Config) -> anyhow::Result<()> {
-        let versions_dir = config.versions_dir();
         let local_versions = config.local_versions();
 
-        match &self.version {
-            Some(version) => {
-                let version = local_versions
-                    .iter()
-                    .filter(|local_version| version.includes(local_version))
-                    .max()
-                    .ok_or(Error::NotInstalledError(*version))?;
+        match &self.version_name {
+            Some(version_name) => {
+                let (version_dir, version) = match version_name {
+                    VersionName::Version(version) => {
+                        // find latest version installed
+                        let version = local_versions
+                            .iter()
+                            .filter(|local_version| version.includes(local_version))
+                            .max()
+                            .ok_or(Error::NotInstalledError(*version))?;
+                        (config.versions_dir().join(version.to_string()), *version)
+                    }
+                    VersionName::Alias(alias) => {
+                        let (version_dir, version) = alias.resolve(config.aliases_dir())?;
+                        println!("Resolve alias: `{}` -> {:?}", alias, version_dir);
+                        (version_dir, version)
+                    }
+                };
 
                 let multishell_path = config.multishell_path.as_ref().unwrap();
-                let is_first_using = if multishell_path.exists() {
+                let is_used_yet = multishell_path.exists();
+                if is_used_yet {
                     symlink::remove(multishell_path).expect("Can't remove symlink!");
-                    false
-                } else {
-                    true
-                };
-                let new_original = versions_dir.join(version.to_string());
-                symlink::link(new_original, multishell_path).expect("Can't create symlink!");
+                }
+                symlink::link(version_dir, multishell_path).expect("Can't create symlink!");
                 println!("Using {}", version.to_string());
-                if is_first_using {
+                if !is_used_yet {
                     println!(
-                        "{}: Need to run `rehash` in this shell",
+                        "{}: Need to type `rehash` in this shell (only first time)",
                         "warning".yellow().bold()
                     );
                 }
             }
-            None => todo!(),
+            None => todo!("use .php-version"),
         }
         Ok(())
+    }
+}
+
+impl FromStr for VersionName {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(s.parse::<Version>()
+            .map_or(Self::Alias(s.parse().unwrap()), |v| Self::Version(v)))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod alias;
 pub mod commands;
 pub mod curl;
 pub mod release;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,8 @@ fn main() {
         SubCommand::Use(cmd) => cmd.run(&config),
         SubCommand::Current(cmd) => cmd.run(&config),
         SubCommand::Uninstall(cmd) => cmd.run(&config),
+        SubCommand::Alias(cmd) => cmd.run(&config),
+        SubCommand::Unalias(cmd) => cmd.run(&config),
     };
     if let Err(e) = result {
         eprintln!("{}: {}", "error".red().bold(), e);
@@ -49,4 +51,10 @@ pub enum SubCommand {
 
     #[structopt(name = "uninstall")]
     Uninstall(commands::Uninstall),
+
+    #[structopt(name = "alias")]
+    Alias(commands::Alias),
+
+    #[structopt(name = "unalias")]
+    Unalias(commands::Unalias),
 }


### PR DESCRIPTION
## alias
```
phpup alias <version> <alias>   
```
Create a symblic link `.phpup/aliases/{alias}` to `.phpup/versions/php/{version}`

## list-local, list-remote
List versions and alias

## use
Can specify version via alias

## unalias
Remove `.phpup/aliases/{alias}`

## uninstall
Remove all aliases which link to specified version
