### PR TITLE
Switching via `.php-version` & Automatically switching when `cd`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,6 +628,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a75aeaaef0ce18b58056d306c27b07436fbb34b8816c53094b76dd81803136"
+dependencies = [
+ "unindent",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,6 +980,7 @@ dependencies = [
  "derive_more",
  "dirs",
  "flate2",
+ "indoc",
  "itertools",
  "num_cpus",
  "octocrab",
@@ -1644,6 +1654,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "unindent"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ dirs = "1.0.4"
 tempfile = "3.2.0"
 num_cpus = "1.13.1"
 colored = "1.6.1"
+indoc = "1.0.3"
 
 octocrab = "0.15.3"
 # async-trait = "0.1.52"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [WIP] PHP-UP: Fast and Simple PHP version manager
+# PHP-UP: Fast and Simple PHP version manager
 
 :zap: Fast and simple PHP version manager, written in rust
 
@@ -6,7 +6,7 @@
 
 - No requirements for system PHP installation
 - Cross-platform support (macOS, Linux)
-- [WIP] Automatically version switching with `.php-version`
+- Automatically version switching with `.php-version`
 
 ## :wrench: Installation
 

--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@
 - [x] alias
 - [ ] defaut alias
 - [ ] automatically `use` when `install` first time
-- [ ] auto version switching via `.php-version`
+- [x] auto version switching via `.php-version`
 - [ ] colorize output
 - [ ] embed system php version
 - [x] shell completion

--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -19,12 +19,8 @@ pub enum Error {
 impl Command for Alias {
     type Error = Error;
     fn run(&self, config: &Config) -> Result<(), Error> {
-        let local_versions = config.local_versions();
-        // TODO: funcionarize
-        let version = local_versions
-            .iter()
-            .filter(|local_version| self.version.includes(local_version))
-            .max()
+        let version = config
+            .latest_local_version_included_in(&self.version)
             .ok_or(Error::NotInstalledError(self.version))?;
 
         let alias_symlink = self.alias.symlink_path(&config.aliases_dir());

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -26,19 +26,15 @@ impl Command for Install {
     type Error = Error;
     fn run(&self, config: &Config) -> Result<(), Error> {
         let versions_dir = config.versions_dir();
-        let local_versions = config.local_versions();
 
         match &self.version {
             Some(version) => {
-                let installed_version = local_versions
-                    .iter()
-                    .filter(|local_version| version.includes(local_version))
-                    .max();
+                let installed_version = config.latest_local_version_included_in(version);
                 if let Some(installed_version) = installed_version {
                     println!(
-                        "{}: Already installed {}",
+                        "{}: Already installed PHP {}",
                         "warning".yellow().bold(),
-                        installed_version
+                        installed_version.to_string().cyan()
                     );
                     return Ok(());
                 }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -34,18 +34,9 @@ impl Command for Install {
     fn run(&self, config: &Config) -> Result<(), Error> {
         let versions_dir = config.versions_dir();
 
-        let request_version = match self.version {
-            Some(version) => version,
-            None => {
-                let (version, version_file_path) = self.version_file.get_version()?;
-                println!(
-                    "Detected {} from {:?}",
-                    version.to_string().cyan(),
-                    version_file_path
-                );
-                version
-            }
-        };
+        let request_version = self
+            .version
+            .unwrap_or(self.get_version_from_version_file()?);
 
         let release = release::fetch_latest(request_version)?;
         let install_version = release.version.unwrap();
@@ -109,6 +100,16 @@ impl Command for Install {
 }
 
 impl Install {
+    fn get_version_from_version_file(&self) -> Result<Version, Error> {
+        let (version, version_file_path) = self.version_file.get_version()?;
+        println!(
+            "Detected {} from {:?}",
+            version.to_string().cyan(),
+            version_file_path
+        );
+        Ok(version)
+    }
+
     // TODO: checksum
     fn download_and_unpack(url: &str, path: impl AsRef<Path>) {
         let response = curl::get_as_reader(url);

--- a/src/commands/list_local.rs
+++ b/src/commands/list_local.rs
@@ -21,10 +21,9 @@ impl Command for ListLocal {
         let printer = Printer::new(&local_versions, config.current_version(), &aliases);
 
         match &self.version {
-            Some(version) => local_versions
-                .iter()
-                .filter(|local_version| version.includes(local_version))
-                .for_each(|&local_version| printer.print_version(local_version)),
+            Some(version) => config
+                .local_versions_included_in(version)
+                .for_each(|local_version| printer.print_version(local_version)),
             None => local_versions
                 .iter()
                 .for_each(|&local_version| printer.print_version(local_version)),

--- a/src/commands/use.rs
+++ b/src/commands/use.rs
@@ -1,7 +1,8 @@
 use super::{Command, Config, ConfigError};
-use crate::alias::Alias;
+use crate::alias::{self, Alias};
 use crate::symlink;
 use crate::version::Version;
+use crate::version_file::{self, VersionFile};
 use clap;
 use colored::Colorize;
 use derive_more::Display;
@@ -12,6 +13,9 @@ use thiserror::Error;
 pub struct Use {
     #[clap(name = "version | alias", help = "semantic version or alias name")]
     version_name: Option<VersionName>,
+
+    #[clap(flatten)]
+    version_file: VersionFile,
 }
 
 #[derive(Debug, Display)]
@@ -24,10 +28,15 @@ enum VersionName {
 pub enum Error {
     #[error("Can't find installed version `{0}`")]
     NotInstalledError(Version),
+
     #[error(transparent)]
     NoMultiShellPathError(#[from] ConfigError),
+
     #[error(transparent)]
-    NotFoundAliasError(#[from] crate::alias::Error),
+    NotFoundAliasError(#[from] alias::Error),
+
+    #[error("Can't detect a version: {0}")]
+    NoVersionFromFileError(#[from] version_file::Error),
 }
 
 impl Command for Use {
@@ -35,40 +44,52 @@ impl Command for Use {
     fn run(&self, config: &Config) -> Result<(), Error> {
         let local_versions = config.local_versions();
 
-        match &self.version_name {
+        let request_version = match &self.version_name {
             Some(version_name) => {
-                let (version_dir, version) = match version_name {
+                match version_name {
                     VersionName::Version(version) => {
                         // find latest version installed
-                        let version = local_versions
+                        *local_versions
                             .iter()
                             .filter(|local_version| version.includes(local_version))
                             .max()
-                            .ok_or(Error::NotInstalledError(*version))?;
-                        (config.versions_dir().join(version.to_string()), *version)
+                            .ok_or(Error::NotInstalledError(*version))?
                     }
                     VersionName::Alias(alias) => {
-                        let (version_dir, version) = alias.resolve(config.aliases_dir())?;
-                        println!("Resolve alias: `{}` -> {:?}", alias, version_dir);
-                        (version_dir, version)
+                        let (_, version) = alias.resolve(config.aliases_dir())?;
+                        println!("Resolve alias: {} -> {}", alias, version.to_string().cyan());
+                        version
                     }
-                };
-
-                let multishell_path = config.multishell_path()?;
-                let is_used_yet = multishell_path.exists();
-                if is_used_yet {
-                    symlink::remove(multishell_path).expect("Can't remove symlink!");
-                }
-                symlink::link(version_dir, multishell_path).expect("Can't create symlink!");
-                println!("Using {}", version);
-                if !is_used_yet {
-                    println!(
-                        "{}: Need to type `rehash` in this shell if you are using zsh (only first time)",
-                        "warning".yellow().bold()
-                    );
                 }
             }
-            None => todo!("use .php-version"),
+            None => {
+                let (version, version_file_path) = self.version_file.get_version()?;
+                println!(
+                    "Detect {} from {:?}",
+                    version.to_string().cyan(),
+                    version_file_path
+                );
+                *local_versions
+                    .iter()
+                    .filter(|local_version| version.includes(local_version))
+                    .max()
+                    .ok_or(Error::NotInstalledError(version))?
+            }
+        };
+
+        let multishell_path = config.multishell_path()?;
+        let is_used_yet = multishell_path.exists();
+        let version_dir = config.versions_dir().join(request_version.to_string());
+
+        symlink::remove(multishell_path).expect("Can't remove symlink!");
+        symlink::link(version_dir, multishell_path).expect("Can't create symlink!");
+
+        println!("Using PHP {}", request_version.to_string().cyan());
+        if !is_used_yet {
+            println!(
+                "{}: Need to type `rehash` in this shell if you are using zsh (only first time)",
+                "warning".yellow().bold()
+            );
         }
         Ok(())
     }

--- a/src/commands/use.rs
+++ b/src/commands/use.rs
@@ -6,6 +6,7 @@ use crate::version_file::{self, VersionFile};
 use clap;
 use colored::Colorize;
 use derive_more::Display;
+use std::fs;
 use std::str::FromStr;
 use thiserror::Error;
 

--- a/src/commands/use.rs
+++ b/src/commands/use.rs
@@ -6,7 +6,6 @@ use crate::version_file::{self, VersionFile};
 use clap;
 use colored::Colorize;
 use derive_more::Display;
-use std::fs;
 use std::str::FromStr;
 use thiserror::Error;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -95,6 +95,17 @@ impl Config {
             .sorted()
             .collect()
     }
+    pub fn local_versions_included_in<'a>(
+        &self,
+        version: &'a Version,
+    ) -> impl Iterator<Item = Version> + 'a {
+        self.local_versions()
+            .into_iter()
+            .filter(|local_version| version.includes(local_version))
+    }
+    pub fn latest_local_version_included_in(&self, version: &Version) -> Option<Version> {
+        self.local_versions_included_in(version).max()
+    }
     pub fn aliases(&self) -> HashMap<Version, Vec<crate::alias::Alias>> {
         use crate::alias::Alias;
         let aliases_dir = self.aliases_dir();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,3 +7,4 @@ pub mod release;
 pub mod shell;
 pub mod symlink;
 pub mod version;
+pub mod version_file;

--- a/src/symlink.rs
+++ b/src/symlink.rs
@@ -8,6 +8,8 @@ pub fn link<P: AsRef<Path>, U: AsRef<Path>>(original: P, link: U) -> std::io::Re
 
 #[cfg(unix)]
 pub fn remove<P: AsRef<Path>>(symlink_file: P) -> std::io::Result<()> {
-    std::fs::remove_file(symlink_file)?;
+    if std::fs::symlink_metadata(&symlink_file).is_ok() {
+        std::fs::remove_file(symlink_file)?;
+    }
     Ok(())
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -127,13 +127,14 @@ impl Version {
 }
 
 #[derive(Error, Debug)]
-pub enum Error {
+pub enum ParseError {
     #[error("Invalid version format: \"{0}\"")]
     InvalidVersionFormat(String),
 }
 
 impl FromStr for Version {
-    type Err = Error;
+    type Err = ParseError;
+
     fn from_str(s: &str) -> core::result::Result<Self, Self::Err> {
         if s == "3.0.x (latest)" {
             return Ok(Version::from_numbers(
@@ -144,7 +145,7 @@ impl FromStr for Version {
         }
         let cap = VERSION_REGEX
             .captures(s)
-            .ok_or(Error::InvalidVersionFormat(s.to_owned()))?;
+            .ok_or(ParseError::InvalidVersionFormat(s.to_owned()))?;
         let to_num = |m: regex::Match| m.as_str().parse().unwrap();
         let major = Major {
             version: to_num(cap.get(1).unwrap()),

--- a/src/version_file.rs
+++ b/src/version_file.rs
@@ -1,0 +1,130 @@
+use crate::version::{ParseError, Version};
+use std::fs;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+const DEFAULT_VERSION_FILE_NAME: &str = ".php-version";
+
+#[derive(clap::Parser, Debug)]
+pub struct VersionFile {
+    /// Spacify a custom version file name
+    #[clap(long, env = "PHPUP_VERSION_FILE_NAME", default_value = DEFAULT_VERSION_FILE_NAME)]
+    version_file_name: PathBuf,
+
+    /// Enable recursive search in a parent dirctory for a version file
+    #[clap(long, env = "PHPUP_RECURSIVE_VERSION_FILE")]
+    recursive_version_file: bool,
+}
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Can't parse string written in {filepath}: {source}")]
+    VersionParseError {
+        filepath: PathBuf,
+        #[source]
+        source: ParseError,
+    },
+    #[error("Can't find a version file: \"{0}\"")]
+    NoVersionFileError(PathBuf),
+}
+
+impl VersionFile {
+    pub fn get_version(&self) -> Result<(Version, PathBuf), Error> {
+        let current_dir = std::env::current_dir().expect("Can't get a current directory");
+        if self.recursive_version_file {
+            self.search_recursively(current_dir)
+        } else {
+            self.search_current(current_dir)?
+                .ok_or(Error::NoVersionFileError(self.version_file_name.clone()))
+        }
+    }
+
+    fn search_current(
+        &self,
+        current_dir: impl AsRef<Path>,
+    ) -> Result<Option<(Version, PathBuf)>, Error> {
+        let filepath = current_dir.as_ref().join(self.version_file_name.as_path());
+        fs::read_to_string(&filepath)
+            .ok()
+            .map(|string| {
+                string
+                    .trim()
+                    .parse::<Version>()
+                    .or_else(|source| {
+                        Err(Error::VersionParseError {
+                            filepath: filepath.clone(),
+                            source,
+                        })
+                    })
+                    .map(|v| (v, filepath))
+            })
+            .transpose()
+    }
+
+    fn search_recursively(
+        &self,
+        current_dir: impl AsRef<Path>,
+    ) -> Result<(Version, PathBuf), Error> {
+        let mut searching_dir = Some(current_dir.as_ref());
+        while let Some(dir) = searching_dir {
+            if let Some(version_info) = self.search_current(dir)? {
+                return Ok(version_info);
+            }
+            searching_dir = dir.parent()
+        }
+        Err(Error::NoVersionFileError(self.version_file_name.clone()))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::{fs, io::Write};
+
+    #[test]
+    fn search_current_success() {
+        let module = VersionFile {
+            version_file_name: PathBuf::from(".php-version"),
+            recursive_version_file: false,
+        };
+
+        let current_dir = tempfile::tempdir().unwrap();
+        let version_file_path = current_dir.path().join(".php-version");
+        fs::File::create(&version_file_path)
+            .unwrap()
+            .write_all(b"8.1.1")
+            .unwrap();
+
+        let version_info = module.search_current(current_dir);
+
+        assert!(version_info.is_ok());
+        assert_eq!(
+            version_info.unwrap(),
+            Some(("8.1.1".parse().unwrap(), version_file_path))
+        );
+    }
+
+    #[test]
+    fn search_recursively_success() {
+        let module = VersionFile {
+            version_file_name: PathBuf::from(".php-version"),
+            recursive_version_file: true,
+        };
+
+        let root_dir = tempfile::tempdir().unwrap();
+        let version_file_path = root_dir.path().join(".php-version");
+        fs::File::create(&version_file_path)
+            .unwrap()
+            .write_all(b"8.1.1")
+            .unwrap();
+
+        let current_dir = root_dir.path().join("child").join("grand_child");
+        let version_info = module.search_recursively(current_dir);
+
+        assert!(version_info.is_ok());
+        assert_eq!(
+            version_info.unwrap(),
+            ("8.1.1".parse().unwrap(), version_file_path)
+        );
+    }
+}


### PR DESCRIPTION
## New Features
### `use`
- use the version specified by a `version-file` such as `.php-version` if no version argument is provided
- recursive searching in a parent directory for a `version-file` if the argument is specified
- custom `version-file`
### `install`
- install the version specified by a `version-file` if no version argument
### `init`
- automatically version switching when changing directory