### PR TITLE
Code refactor: clippy & Error

### DIFF
--- a/src/alias.rs
+++ b/src/alias.rs
@@ -9,9 +9,9 @@ pub struct Alias(String);
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Can't resolve alias: {0}")]
-    NotFoundAliasError(String),
+    NotFoundAlias(String),
     #[error("Can't find version: '{0}'")]
-    NotFoundVersionError(String),
+    NotFoundVersion(String),
 }
 
 impl Alias {
@@ -23,12 +23,12 @@ impl Alias {
         let alias_symlink = self.symlink_path(aliases_dir);
         let version_dir = alias_symlink
             .read_link()
-            .map_err(|_| Error::NotFoundAliasError(self.0.clone()))?;
+            .map_err(|_| Error::NotFoundAlias(self.0.clone()))?;
         let version = version_dir
             .file_name()
             .and_then(|os_str| os_str.to_str())
             .and_then(|s| s.parse::<Version>().ok())
-            .ok_or_else(|| Error::NotFoundVersionError(self.0.clone()))?;
+            .ok_or_else(|| Error::NotFoundVersion(self.0.clone()))?;
         Ok((version_dir, version))
     }
 }

--- a/src/alias.rs
+++ b/src/alias.rs
@@ -23,12 +23,12 @@ impl Alias {
         let alias_symlink = self.symlink_path(aliases_dir);
         let version_dir = alias_symlink
             .read_link()
-            .or(Err(Error::NotFoundAliasError(self.0.clone())))?;
+            .map_err(|_| Error::NotFoundAliasError(self.0.clone()))?;
         let version = version_dir
             .file_name()
             .and_then(|os_str| os_str.to_str())
             .and_then(|s| s.parse::<Version>().ok())
-            .ok_or(Error::NotFoundVersionError(self.0.clone()))?;
+            .ok_or_else(|| Error::NotFoundVersionError(self.0.clone()))?;
         Ok((version_dir, version))
     }
 }

--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -15,7 +15,7 @@ pub struct Alias {
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Can't find installed version '{0}'")]
-    NotInstalledError(Version),
+    NotInstalled(Version),
 }
 
 impl Command for Alias {
@@ -23,7 +23,7 @@ impl Command for Alias {
     fn run(&self, config: &Config) -> Result<(), Error> {
         let version = config
             .latest_local_version_included_in(&self.version)
-            .ok_or(Error::NotInstalledError(self.version))?;
+            .ok_or(Error::NotInstalled(self.version))?;
 
         let alias_symlink = self.alias.symlink_path(&config.aliases_dir());
         if alias_symlink.exists() {

--- a/src/commands/completions.rs
+++ b/src/commands/completions.rs
@@ -23,7 +23,7 @@ impl Command for Completions {
     fn run(&self, _: &Config) -> Result<(), Error> {
         let shell = self
             .shell
-            .map_or_else(|| Shell::detect_shell(), Ok)?
+            .map_or_else(Shell::detect_shell, Ok)?
             .to_clap_shell();
         let app = Cli::into_app();
         let mut stdout = std::io::stdout();

--- a/src/commands/current.rs
+++ b/src/commands/current.rs
@@ -12,7 +12,7 @@ impl Command for Current {
     type Error = Error;
     fn run(&self, config: &Config) -> Result<(), Error> {
         if let Some(version) = config.current_version() {
-            println!("{}", version.to_string());
+            println!("{}", version);
         } else {
             println!("none");
         }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -49,7 +49,6 @@ impl Command for Init {
 fn create_symlink() -> std::path::PathBuf {
     let temp_dir = std::env::temp_dir().join("phpup");
     std::fs::create_dir_all(&temp_dir).expect("Can't create tempdir!");
-    
 
     // TODO: default version
     // symlink::link(&default_version_dir, &symlink_path).expect("Can't create symlink!");

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -29,7 +29,7 @@ pub enum Error {
 impl Command for Init {
     type Error = Error;
     fn run(&self, _config: &Config) -> Result<(), Error> {
-        let shell = self.shell.map_or_else(|| Shell::detect_shell(), Ok)?;
+        let shell = self.shell.map_or_else(Shell::detect_shell, Ok)?;
         let symlink = create_symlink();
         let mut eval_stmts = vec![
             shell.set_env("PHPUP_MULTISHELL_PATH", symlink.to_str().unwrap()),
@@ -49,16 +49,16 @@ impl Command for Init {
 fn create_symlink() -> std::path::PathBuf {
     let temp_dir = std::env::temp_dir().join("phpup");
     std::fs::create_dir_all(&temp_dir).expect("Can't create tempdir!");
-    let symlink_path = loop {
+    
+
+    // TODO: default version
+    // symlink::link(&default_version_dir, &symlink_path).expect("Can't create symlink!");
+    loop {
         let symlink_path = temp_dir.join(generate_symlink_path());
         if !symlink_path.exists() {
             break symlink_path;
         }
-    };
-
-    // TODO: default version
-    // symlink::link(&default_version_dir, &symlink_path).expect("Can't create symlink!");
-    symlink_path
+    }
 }
 
 fn generate_symlink_path() -> PathBuf {

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -127,7 +127,7 @@ impl Install {
         if !configure.status.success() {
             println!(
                 "configure failed: {}",
-                String::from_utf8_lossy(&configure.stderr).to_string()
+                String::from_utf8_lossy(&configure.stderr)
             );
             return Err(());
         };
@@ -142,7 +142,7 @@ impl Install {
         if !make.status.success() {
             println!(
                 "make failed: {}",
-                String::from_utf8_lossy(&make.stderr).to_string()
+                String::from_utf8_lossy(&make.stderr)
             );
             return Err(());
         };
@@ -156,7 +156,7 @@ impl Install {
         if !make_install.status.success() {
             println!(
                 "make install: {}",
-                String::from_utf8_lossy(&make_install.stderr).to_string()
+                String::from_utf8_lossy(&make_install.stderr)
             );
             return Err(());
         };

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -24,10 +24,10 @@ pub struct Install {
 #[derive(Error, Debug)]
 pub enum Error {
     #[error(transparent)]
-    CantFetchReleaseError(#[from] release::Error),
+    FailedFetchRelease(#[from] release::FetchError),
 
     #[error("Can't detect a version: {0}")]
-    NoVersionFromFileError(#[from] version_file::Error),
+    NoVersionFromFile(#[from] version_file::Error),
 }
 
 impl Command for Install {
@@ -140,10 +140,7 @@ impl Install {
             .output()
             .unwrap();
         if !make.status.success() {
-            println!(
-                "make failed: {}",
-                String::from_utf8_lossy(&make.stderr)
-            );
+            println!("make failed: {}", String::from_utf8_lossy(&make.stderr));
             return Err(());
         };
 

--- a/src/commands/list_remote.rs
+++ b/src/commands/list_remote.rs
@@ -27,7 +27,7 @@ pub struct ListRemote {
 #[derive(Error, Debug)]
 pub enum Error {
     #[error(transparent)]
-    CantFetchReleaseError(#[from] release::Error),
+    FailedFetchRelease(#[from] release::FetchError),
 }
 
 impl Command for ListRemote {

--- a/src/commands/unalias.rs
+++ b/src/commands/unalias.rs
@@ -23,7 +23,7 @@ impl Command for Unalias {
         if alias_symlink.exists() {
             fs::remove_file(&alias_symlink).expect("Can't remove alias symbolic link");
         } else {
-            return Err(Error::NotFoundAliasError(self.alias.to_string()))?;
+            return Err(Error::NotFoundAliasError(self.alias.to_string()));
         }
         println!("Remove the alias {}", self.alias.decorized());
         Ok(())

--- a/src/commands/unalias.rs
+++ b/src/commands/unalias.rs
@@ -13,7 +13,7 @@ pub struct Unalias {
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Can't find alias '{0}'")]
-    NotFoundAliasError(String),
+    NotFoundAlias(String),
 }
 
 impl Command for Unalias {
@@ -23,7 +23,7 @@ impl Command for Unalias {
         if alias_symlink.exists() {
             fs::remove_file(&alias_symlink).expect("Can't remove alias symbolic link");
         } else {
-            return Err(Error::NotFoundAliasError(self.alias.to_string()));
+            return Err(Error::NotFoundAlias(self.alias.to_string()));
         }
         println!("Remove the alias {}", self.alias.decorized());
         Ok(())

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -14,9 +14,9 @@ pub struct Uninstall {
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Can't find installed version '{0}'")]
-    NotInstalledError(Version),
+    NotInstalled(Version),
     #[error(transparent)]
-    NoMultiShellPathError(#[from] ConfigError),
+    NoMultiShellPath(#[from] ConfigError),
 }
 
 impl Command for Uninstall {
@@ -25,7 +25,7 @@ impl Command for Uninstall {
         let uninstall_version = config
             .local_versions()
             .find(|local| local == &self.version)
-            .ok_or(Error::NotInstalledError(self.version))?;
+            .ok_or(Error::NotInstalled(self.version))?;
 
         if config.current_version() == Some(uninstall_version) {
             symlink::remove(&config.multishell_path()?).expect("Can't remove symlink!");

--- a/src/commands/use.rs
+++ b/src/commands/use.rs
@@ -33,19 +33,19 @@ enum VersionName {
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Can't find installed version '{0}'")]
-    NotInstalledError(Version),
+    NotInstalled(Version),
 
     #[error(transparent)]
-    NoMultiShellPathError(#[from] ConfigError),
+    NoMultiShellPath(#[from] ConfigError),
 
     #[error(transparent)]
-    NotFoundAliasError(#[from] alias::Error),
+    NotFoundAlias(#[from] alias::Error),
 
     #[error("Can't detect a version: {0}")]
-    NoVersionFromFileError(#[from] version_file::Error),
+    NoVersionFromFile(#[from] version_file::Error),
 
     #[error("Can't find installed version '{0}', specified by '{1}'")]
-    NotInstalledFromFileError(Version, PathBuf),
+    NotInstalledFromFile(Version, PathBuf),
 }
 
 macro_rules! outln {
@@ -63,7 +63,7 @@ impl Command for Use {
             Some(version_name) => match version_name {
                 VersionName::Version(version) => config
                     .latest_local_version_included_in(version)
-                    .ok_or(Error::NotInstalledError(*version))?,
+                    .ok_or(Error::NotInstalled(*version))?,
                 VersionName::Alias(alias) => {
                     let (_, version) = alias.resolve(config.aliases_dir())?;
                     outln!(
@@ -77,7 +77,7 @@ impl Command for Use {
             },
             None => {
                 let info = match self.version_file.get_version_info() {
-                    Err(version_file::Error::NoVersionFileError(_)) if self.quiet => return Ok(()),
+                    Err(version_file::Error::NoVersionFile(_)) if self.quiet => return Ok(()),
                     other => other,
                 }?;
                 outln!(
@@ -88,10 +88,7 @@ impl Command for Use {
                 );
                 config
                     .latest_local_version_included_in(&info.version)
-                    .ok_or(Error::NotInstalledFromFileError(
-                        info.version,
-                        info.filepath,
-                    ))?
+                    .ok_or(Error::NotInstalledFromFile(info.version, info.filepath))?
             }
         };
 

--- a/src/commands/use.rs
+++ b/src/commands/use.rs
@@ -122,6 +122,6 @@ impl FromStr for VersionName {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(s.parse::<Version>()
-            .map_or(Self::Alias(s.parse().unwrap()), |v| Self::Version(v)))
+            .map_or(Self::Alias(s.parse().unwrap()), Self::Version))
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
-#[derive(clap::Parser, Debug)]
+#[derive(clap::Parser, Debug, Default)]
 pub struct Config {
     /// Specify a custom PHP-UP directory
     #[clap(long = "phpup-dir", env = "PHPUP_DIR")]
@@ -23,18 +23,10 @@ pub enum Error {
     NoMultiShellPathError,
 }
 
-impl std::default::Default for Config {
-    fn default() -> Self {
-        Self {
-            base_dir: None,
-            multishell_path: None,
-        }
-    }
-}
-
 impl Config {
     pub fn multishell_path(&self) -> Result<&Path, Error> {
-        self.multishell_path.as_deref()
+        self.multishell_path
+            .as_deref()
             .ok_or(Error::NoMultiShellPathError)
     }
     pub fn base_dir(&self) -> PathBuf {
@@ -48,8 +40,8 @@ impl Config {
     }
     pub fn versions_dir(&self) -> PathBuf {
         let versions_dir = self.base_dir().join("versions").join("php");
-        fs::create_dir_all(&versions_dir).unwrap_or_else(|_| panic!("Can't create version dirctory: {:?}",
-            versions_dir));
+        fs::create_dir_all(&versions_dir)
+            .unwrap_or_else(|_| panic!("Can't create version dirctory: {:?}", versions_dir));
         versions_dir
     }
     pub fn aliases_dir(&self) -> PathBuf {

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,9 +34,7 @@ impl std::default::Default for Config {
 
 impl Config {
     pub fn multishell_path(&self) -> Result<&Path, Error> {
-        self.multishell_path
-            .as_ref()
-            .map(|path| path.as_path())
+        self.multishell_path.as_deref()
             .ok_or(Error::NoMultiShellPathError)
     }
     pub fn base_dir(&self) -> PathBuf {
@@ -50,16 +48,14 @@ impl Config {
     }
     pub fn versions_dir(&self) -> PathBuf {
         let versions_dir = self.base_dir().join("versions").join("php");
-        fs::create_dir_all(&versions_dir).expect(&format!(
-            "Can't create version dirctory: {:?}",
-            versions_dir
-        ));
+        fs::create_dir_all(&versions_dir).unwrap_or_else(|_| panic!("Can't create version dirctory: {:?}",
+            versions_dir));
         versions_dir
     }
     pub fn aliases_dir(&self) -> PathBuf {
         let aliases_dir = self.base_dir().join("aliases");
         fs::create_dir_all(&aliases_dir)
-            .expect(&format!("Can't create alias dirctory: {:?}", aliases_dir));
+            .unwrap_or_else(|_| panic!("Can't create alias dirctory: {:?}", aliases_dir));
         aliases_dir
     }
     pub fn current_version(&self) -> Option<Version> {
@@ -80,7 +76,7 @@ impl Config {
         let versions_dir = self.versions_dir();
         fs::read_dir(&versions_dir)
             .unwrap()
-            .flat_map(|entry| entry)
+            .flatten()
             .flat_map(|path| path.path().file_name().map(ToOwned::to_owned))
             .flat_map(|dir_os_str| dir_os_str.into_string())
             .flat_map(|dir_str| dir_str.parse::<Version>())
@@ -110,7 +106,7 @@ impl Config {
         let mut map: HashMap<Version, Vec<Alias>> = HashMap::new();
         fs::read_dir(&aliases_dir)
             .unwrap()
-            .flat_map(|entry| entry)
+            .flatten()
             .flat_map(|path| path.path().file_name().map(ToOwned::to_owned))
             .flat_map(|dir_os_str| dir_os_str.into_string())
             .flat_map(|dir_str| dir_str.parse::<Alias>())

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,14 +20,14 @@ pub struct Config {
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Not yet initialized; Need to run `eval \"$(phpup init)\"`")]
-    NoMultiShellPathError,
+    NoMultiShellPath,
 }
 
 impl Config {
     pub fn multishell_path(&self) -> Result<&Path, Error> {
         self.multishell_path
             .as_deref()
-            .ok_or(Error::NoMultiShellPathError)
+            .ok_or(Error::NoMultiShellPath)
     }
     pub fn base_dir(&self) -> PathBuf {
         if let Some(base_dir) = self.base_dir.as_ref() {

--- a/src/decorized.rs
+++ b/src/decorized.rs
@@ -14,7 +14,7 @@ pub trait Decorized: std::fmt::Display {
 impl Decorized for crate::version::Version {
     type Color = color::Cyan;
     fn decorized_with_prefix(&self) -> colored::ColoredString {
-        let with_prefix = format!("PHP {}", self.to_string());
+        let with_prefix = format!("PHP {}", self);
         with_prefix.color(Self::Color::color())
     }
 }

--- a/src/release.rs
+++ b/src/release.rs
@@ -171,10 +171,10 @@ impl Release {
         let release_year = release_date.year();
         let active_support_deadline = release_date
             .with_year(release_year + 2)
-            .unwrap_or(NaiveDate::from_yo(release_year + 1, 1).succ());
+            .unwrap_or_else(|| NaiveDate::from_yo(release_year + 1, 1).succ());
         let security_support_deadline = release_date
             .with_year(release_year + 3)
-            .unwrap_or(NaiveDate::from_yo(release_year + 2, 1).succ());
+            .unwrap_or_else(|| NaiveDate::from_yo(release_year + 2, 1).succ());
         let today = Utc::now().naive_local().date();
 
         if today < active_support_deadline {

--- a/src/release.rs
+++ b/src/release.rs
@@ -178,11 +178,11 @@ impl Release {
         let today = Utc::now().naive_local().date();
 
         if today < active_support_deadline {
-            return Support::ActiveSupport;
+            Support::ActiveSupport
         } else if today < security_support_deadline {
-            return Support::SecurityFixesOnly;
+            Support::SecurityFixesOnly
         } else {
-            return Support::EndOfLife;
+            Support::EndOfLife
         }
     }
 }
@@ -265,7 +265,7 @@ mod tests {
                 }
             }
         "#;
-        let resp: Result<Response, _> = serde_json::from_str(&json);
+        let resp: Result<Response, _> = serde_json::from_str(json);
         assert!(resp.is_ok());
         let resp = resp.unwrap();
         assert!(if let Response::Map(map) = resp {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -182,8 +182,7 @@ fn get_process_info(pid: u32) -> Result<ProcessInfo, ProcessInfoError> {
 
     Ok(ProcessInfo {
         parent_pid: ppid
-            .parse()
-            .or_else(|_| Err(ParseError(line.to_string())))?,
+            .parse().map_err(|_| ParseError(line.to_string()))?,
         command: command.into(),
     })
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -145,7 +145,7 @@ impl FromStr for Version {
         }
         let cap = VERSION_REGEX
             .captures(s)
-            .ok_or(ParseError::InvalidVersionFormat(s.to_owned()))?;
+            .ok_or_else(|| ParseError::InvalidVersionFormat(s.to_owned()))?;
         let to_num = |m: regex::Match| m.as_str().parse().unwrap();
         let major = Major {
             version: to_num(cap.get(1).unwrap()),
@@ -257,14 +257,14 @@ mod tests {
         let version3_1 = Version::from_numbers(3, Some(1), None);
         let version3 = Version::from_numbers(3, None, None);
 
-        assert_eq!(version3.includes(&version3), true);
-        assert_eq!(version3.includes(&version3_1), true);
-        assert_eq!(version3.includes(&version3_1_4), true);
-        assert_eq!(version3_1.includes(&version3), false);
-        assert_eq!(version3_1.includes(&version3_1), true);
-        assert_eq!(version3_1.includes(&version3_1_4), true);
-        assert_eq!(version3_1_4.includes(&version3), false);
-        assert_eq!(version3_1_4.includes(&version3_1), false);
-        assert_eq!(version3_1_4.includes(&version3_1_4), true);
+        assert!(version3.includes(&version3));
+        assert!(version3.includes(&version3_1));
+        assert!(version3.includes(&version3_1_4));
+        assert!(!version3_1.includes(&version3));
+        assert!(version3_1.includes(&version3_1));
+        assert!(version3_1.includes(&version3_1_4));
+        assert!(!version3_1_4.includes(&version3));
+        assert!(!version3_1_4.includes(&version3_1));
+        assert!(version3_1_4.includes(&version3_1_4));
     }
 }

--- a/src/version_file.rs
+++ b/src/version_file.rs
@@ -38,10 +38,10 @@ pub struct VersionFileInfo {
     pub filepath: PathBuf,
 }
 impl VersionFileInfo {
-    fn to_relative_path(self, base_dir: impl AsRef<Path>) -> Self {
+    fn to_relative_path(&self, base_dir: impl AsRef<Path>) -> Self {
         Self {
             version: self.version,
-            filepath: diff_paths(self.filepath, base_dir).unwrap(),
+            filepath: diff_paths(&self.filepath, base_dir).unwrap(),
         }
     }
 }
@@ -59,7 +59,7 @@ impl VersionFile {
             self.search_recursively(&current_dir)
         } else {
             self.search_current(&current_dir)?
-                .ok_or(Error::NoVersionFileError(self.filename.clone()))
+                .ok_or_else(|| Error::NoVersionFileError(self.filename.clone()))
         })
         .map(|info| info.to_relative_path(&current_dir))
     }
@@ -74,10 +74,11 @@ impl VersionFile {
             .map(|string| {
                 string
                     .trim()
-                    .parse::<Version>().map_err(|source| Error::VersionParseError {
-                            filepath: filepath.clone(),
-                            source,
-                        })
+                    .parse::<Version>()
+                    .map_err(|source| Error::VersionParseError {
+                        filepath: filepath.clone(),
+                        source,
+                    })
                     .map(|version| VersionFileInfo { version, filepath })
             })
             .transpose()

--- a/src/version_file.rs
+++ b/src/version_file.rs
@@ -24,13 +24,13 @@ pub struct VersionFile {
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Can't parse string written in {filepath}: {source}")]
-    VersionParseError {
+    FailedParseVersion {
         filepath: PathBuf,
         #[source]
         source: ParseError,
     },
     #[error("Can't find a version file: \"{0}\"")]
-    NoVersionFileError(PathBuf),
+    NoVersionFile(PathBuf),
 }
 
 pub struct VersionFileInfo {
@@ -59,7 +59,7 @@ impl VersionFile {
             self.search_recursively(&current_dir)
         } else {
             self.search_current(&current_dir)?
-                .ok_or_else(|| Error::NoVersionFileError(self.filename.clone()))
+                .ok_or_else(|| Error::NoVersionFile(self.filename.clone()))
         })
         .map(|info| info.to_relative_path(&current_dir))
     }
@@ -75,7 +75,7 @@ impl VersionFile {
                 string
                     .trim()
                     .parse::<Version>()
-                    .map_err(|source| Error::VersionParseError {
+                    .map_err(|source| Error::FailedParseVersion {
                         filepath: filepath.clone(),
                         source,
                     })
@@ -92,7 +92,7 @@ impl VersionFile {
             }
             searching_dir = dir.parent()
         }
-        Err(Error::NoVersionFileError(self.filename.clone()))
+        Err(Error::NoVersionFile(self.filename.clone()))
     }
 }
 

--- a/src/version_file.rs
+++ b/src/version_file.rs
@@ -74,13 +74,10 @@ impl VersionFile {
             .map(|string| {
                 string
                     .trim()
-                    .parse::<Version>()
-                    .or_else(|source| {
-                        Err(Error::VersionParseError {
+                    .parse::<Version>().map_err(|source| Error::VersionParseError {
                             filepath: filepath.clone(),
                             source,
                         })
-                    })
                     .map(|version| VersionFileInfo { version, filepath })
             })
             .transpose()


### PR DESCRIPTION
- `cargo clippy`
- `cargo fmt`
- remove 'Error' postfix for Error enum variants