### PR TITLE
Support clippy 0.1.64

### DIFF
--- a/src/release.rs
+++ b/src/release.rs
@@ -181,7 +181,7 @@ impl Hash {
     }
 }
 
-#[derive(Debug, Clone, Copy, Display, PartialEq)]
+#[derive(Debug, Clone, Copy, Display, PartialEq, Eq)]
 pub enum Support {
     #[display(fmt = "Active support")]
     ActiveSupport,

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -212,7 +212,7 @@ fn get_process_info(pid: u32) -> Result<ProcessInfo, ProcessInfoError> {
     let mut line = String::new();
     BufReader::new(child.stdout.unwrap()).read_line(&mut line)?;
 
-    let mut parts = line.trim().split_whitespace();
+    let mut parts = line.split_whitespace();
     let ppid = parts
         .next()
         .ok_or_else(|| ProcessInfoError::Parse(line.to_string()))?;

--- a/src/version/local.rs
+++ b/src/version/local.rs
@@ -46,7 +46,7 @@ impl Local {
             .and_then(|symlink| symlink.read_link().ok())
             .and_then(|path| {
                 (system::path().as_ref() == Some(&path))
-                    .then(|| Local::System)
+                    .then_some(Local::System)
                     .or_else(|| {
                         path.parent()
                             .unwrap()
@@ -68,9 +68,9 @@ impl Local {
     pub fn to_string_by(&self, installed: bool, used: bool) -> String {
         let output = format!(
             "{:<2}{:<6} {}",
-            installed.then(|| "*").unwrap_or_default(),
+            installed.then_some("*").unwrap_or_default(),
             self,
-            used.then(|| "<-").unwrap_or_default(),
+            used.then_some("<-").unwrap_or_default(),
         );
 
         if used {


### PR DESCRIPTION
### Clippy version
0.1.59 -> 0.1.64
### Clippy Lints
- [derive_partial_eq_without_eq](https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq)
- [trim_split_whitespace](https://rust-lang.github.io/rust-clippy/master/index.html#trim_split_whitespace)
- [unnecessary_lazy_evaluations](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations)