### PR TITLE
Update crate clap from v3.0.5 to v4.0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,41 +71,48 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.10"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a30c3bf9ff12dfe5dae53f0a96e0febcd18420d1c0e7fad77796d9d5c4b5375"
+checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
- "indexmap",
- "lazy_static",
- "os_str_bytes",
+ "clap_lex",
+ "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "3.0.6"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678db4c39c013cc68b54d372bce2efc58e30a0337c497c9032fd196802df3bc3"
+checksum = "dfe581a2035db4174cdbdc91265e1aba50f381577f0510d0ad36c7bc59cc84a3"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.6"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
+checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -317,12 +324,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,16 +343,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "indexmap"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
 
 [[package]]
 name = "indicatif"
@@ -469,18 +460,15 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "pathdiff"
@@ -511,6 +499,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2",
+ "strum",
  "tar",
  "tempfile",
  "thiserror",
@@ -543,11 +532,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -705,6 +694,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,12 +771,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
-
-[[package]]
 name = "thiserror"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,6 +806,12 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
 thiserror = "1.0.30"
-clap = { version = "3.0.5", features = ["derive", "env"] }
-clap_complete = "3.0.6"
+clap = { version = "4.0.18", features = ["derive", "env"] }
+clap_complete = "4.0.3"
 itertools = "0.10.3"
 once_cell = "1.9.0"
 derive_more = "0.99.16"
@@ -35,6 +35,7 @@ indoc = "1.0.3"
 indicatif = "0.16.2"
 md5 = "0.7.0"
 sha2 = "0.10.2"
+strum = { version = "0.24.1", features = ["derive"] }
 
 [profile.release]
 strip = "symbols"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@ use crate::commands::{self, Command};
 use crate::config::Config;
 
 #[derive(clap::Parser, Debug)]
-#[clap(
+#[command(
     name = env!("CARGO_PKG_NAME"),
     version = env!("CARGO_PKG_VERSION"),
     bin_name = "phpup",
@@ -18,47 +18,47 @@ pub struct Cli {
 #[derive(clap::Parser, Debug)]
 pub enum SubCommand {
     /// Initialize and Print shell script required for PHP-UP
-    #[clap(bin_name = "init")]
+    #[command(bin_name = "init")]
     Init(commands::Init),
 
     /// List remote PHP versions
-    #[clap(bin_name = "list-remote", visible_aliases = &["ls-remote"])]
+    #[command(bin_name = "list-remote", visible_aliases = &["ls-remote"])]
     ListRemote(commands::ListRemote),
 
     /// Install a new PHP version
-    #[clap(bin_name = "install")]
+    #[command(bin_name = "install")]
     Install(commands::Install),
 
     /// List local PHP versions
-    #[clap(bin_name = "list", visible_aliases = &["ls"])]
+    #[command(bin_name = "list", visible_aliases = &["ls"])]
     List(commands::ListLocal),
 
     /// Switch PHP version
-    #[clap(bin_name = "use")]
+    #[command(bin_name = "use")]
     Use(commands::Use),
 
     /// Print the current PHP version
-    #[clap(bin_name = "current")]
+    #[command(bin_name = "current")]
     Current(commands::Current),
 
     /// Uninstall a PHP version
-    #[clap(bin_name = "uninstall")]
+    #[command(bin_name = "uninstall")]
     Uninstall(commands::Uninstall),
 
     /// Alias a version to a common name
-    #[clap(bin_name = "alias")]
+    #[command(bin_name = "alias")]
     Alias(commands::Alias),
 
     /// Remove an alias definition
-    #[clap(bin_name = "unalias")]
+    #[command(bin_name = "unalias")]
     Unalias(commands::Unalias),
 
     /// Set a version as the default version
-    #[clap(bin_name = "default")]
+    #[command(bin_name = "default")]
     Default(commands::Default),
 
     /// Print shell completions
-    #[clap(bin_name = "completions")]
+    #[command(bin_name = "completions")]
     Completions(commands::Completions),
 }
 

--- a/src/commands/completions.rs
+++ b/src/commands/completions.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 
 #[derive(clap::Parser, Debug)]
 pub struct Completions {
-    #[clap(long, value_parser = clap_enum_variants!(Shell))]
+    #[arg(long, value_parser = clap_enum_variants!(Shell))]
     shell: Option<Shell>,
 }
 

--- a/src/commands/completions.rs
+++ b/src/commands/completions.rs
@@ -1,13 +1,14 @@
 use super::{Command, Config};
+use crate::clap_enum_variants;
 use crate::cli::Cli;
 use crate::shell::{self, Shell};
-use clap::{self, IntoApp};
-use clap_complete::Generator;
+use clap::{self, CommandFactory};
+use clap_complete::generate;
 use thiserror::Error;
 
 #[derive(clap::Parser, Debug)]
 pub struct Completions {
-    #[clap(long, possible_values(shell::available_shells()))]
+    #[clap(long, value_parser = clap_enum_variants!(Shell))]
     shell: Option<Shell>,
 }
 
@@ -25,9 +26,10 @@ impl Command for Completions {
             .shell
             .map_or_else(Shell::detect_shell, Ok)?
             .to_clap_shell();
-        let app = Cli::into_app();
+        let mut app = Cli::command();
+        let bin_name = app.get_name().to_string();
         let mut stdout = std::io::stdout();
-        shell.generate(&app, &mut stdout);
+        generate(shell, &mut app, bin_name, &mut stdout);
         Ok(())
     }
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,10 +1,8 @@
 use super::{Command, Config};
+use crate::clap_enum_variants;
 use crate::shell::{self, Shell};
 use crate::symlink;
-use crate::version;
-use crate::version::system;
-use crate::version::Alias;
-use crate::version::Local;
+use crate::version::{self, system, Alias, Local};
 use clap;
 use std::path::PathBuf;
 use thiserror::Error;
@@ -12,7 +10,7 @@ use thiserror::Error;
 #[derive(clap::Parser, Debug)]
 pub struct Init {
     /// Spacify a shell type
-    #[clap(long, possible_values(shell::available_shells()))]
+    #[clap(long, value_parser = clap_enum_variants!(Shell))]
     shell: Option<Shell>,
 
     /// Enable automatically version switching when changing directory

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -10,11 +10,11 @@ use thiserror::Error;
 #[derive(clap::Parser, Debug)]
 pub struct Init {
     /// Spacify a shell type
-    #[clap(long, value_parser = clap_enum_variants!(Shell))]
+    #[arg(long, value_parser = clap_enum_variants!(Shell))]
     shell: Option<Shell>,
 
     /// Enable automatically version switching when changing directory
-    #[clap(long, visible_alias = "auto")]
+    #[arg(long, visible_alias = "auto")]
     auto_switch: bool,
 
     #[clap(flatten)]

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -35,7 +35,7 @@ pub struct Install {
 
     /// Specify configure options used by the PHP configure scripts.
     /// To specify two or more options, enclose them with quotation marks.
-    #[clap(long, env = "PHPUP_CONFIGURE_OPTS", allow_hyphen_values = true)]
+    #[arg(long, env = "PHPUP_CONFIGURE_OPTS", allow_hyphen_values = true)]
     configure_opts: Option<String>,
 }
 

--- a/src/commands/list_remote.rs
+++ b/src/commands/list_remote.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 #[derive(clap::Parser, Debug)]
 pub struct ListRemote {
     version: Option<Version>,
-    #[clap(
+    #[arg(
         long = "latest-patch",
         visible_alias = "lp",
         help = "List latest patch release (avairable only if patch number is NOT specified)"

--- a/src/commands/use.rs
+++ b/src/commands/use.rs
@@ -13,8 +13,8 @@ use thiserror::Error;
 
 #[derive(clap::Parser, Debug)]
 pub struct Use {
-    #[clap(
-        name = "version | alias | system",
+    #[arg(
+        value_name = "version | alias | system",
         help = "installed version or alias name or system"
     )]
     request_version: Option<RequestVersion>,
@@ -23,7 +23,7 @@ pub struct Use {
     version_file: version::File,
 
     /// Don't output a message to stdout
-    #[clap(long)]
+    #[arg(long)]
     quiet: bool,
 }
 

--- a/src/commands/use.rs
+++ b/src/commands/use.rs
@@ -27,7 +27,7 @@ pub struct Use {
     quiet: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum RequestVersion {
     Installed(Version),
     Alias(Alias),

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,11 +6,11 @@ use thiserror::Error;
 #[derive(clap::Parser, Debug, Default)]
 pub struct Config {
     /// Specify a custom PHP-UP directory
-    #[clap(long = "phpup-dir", env = "PHPUP_DIR")]
+    #[arg(long = "phpup-dir", env = "PHPUP_DIR")]
     base_dir: Option<PathBuf>,
 
     /// Specify a custom symbolic link used for version switching
-    #[clap(long, env = "PHPUP_MULTISHELL_PATH", hide = true)]
+    #[arg(long, env = "PHPUP_MULTISHELL_PATH", hide = true)]
     multishell_path: Option<PathBuf>,
 }
 

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -3,17 +3,15 @@ use indoc::formatdoc;
 use std::fmt::Display;
 use std::path::Path;
 use std::str::FromStr;
+use strum::EnumVariantNames;
 use thiserror::Error;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, EnumVariantNames)]
+#[strum(serialize_all = "lowercase")]
 pub enum Shell {
     Bash,
     Zsh,
     Fish,
-}
-
-pub const fn available_shells() -> &'static [&'static str] {
-    &["bash", "zsh", "fish"]
 }
 
 #[derive(Debug, Error)]
@@ -158,6 +156,16 @@ impl FromStr for Shell {
             _ => Err(ParseShellError::UnknownShell(s.to_owned())),
         }
     }
+}
+
+// Based on https://github.com/clap-rs/clap/discussions/4264
+#[macro_export]
+macro_rules! clap_enum_variants {
+    ($e: ty) => {{
+        use clap::builder::TypedValueParser;
+        use strum::VariantNames;
+        clap::builder::PossibleValuesParser::new(<$e>::VARIANTS).map(|s| s.parse::<$e>().unwrap())
+    }};
 }
 
 struct ProcessInfo {

--- a/src/version/file.rs
+++ b/src/version/file.rs
@@ -9,11 +9,11 @@ const DEFAULT_VERSION_FILE_NAME: &str = ".php-version";
 #[derive(clap::Parser, Debug)]
 pub struct File {
     /// Spacify a custom version file name
-    #[clap(long = "version-file-name", env = "PHPUP_VERSION_FILE_NAME", default_value = DEFAULT_VERSION_FILE_NAME)]
+    #[arg(long = "version-file-name", env = "PHPUP_VERSION_FILE_NAME", default_value = DEFAULT_VERSION_FILE_NAME)]
     filename: PathBuf,
 
     /// Enable recursive search in a parent dirctory for a version file
-    #[clap(
+    #[arg(
         long = "recursive-version-file",
         visible_alias = "recursive",
         env = "PHPUP_RECURSIVE_VERSION_FILE"


### PR DESCRIPTION
### update clap v3 -> v4
- [clap v4 Change Log](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#400---2022-09-28)